### PR TITLE
fixed missing version warning and added right encoding

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -91,10 +91,15 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-failsafe-plugin</artifactId>
+                <version>2.19.1</version>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
+                <version>2.19.1</version>
+                <configuration>
+                    <argLine>-Dfile.encoding=${project.build.sourceEncoding}</argLine>
+                </configuration>
             </plugin>
         </plugins>
     </build>


### PR DESCRIPTION
Got the following error:

`
Some problems were encountered while building the effective model for de.rub.nds.tlsscanner:TLS-Scanner:jar:2.0Beta2
'build.plugins.plugin.version' for org.apache.maven.plugins:maven-surefire-plugin is missing. @ line 95, column 21
'build.plugins.plugin.version' for org.apache.maven.plugins:maven-failsafe-plugin is missing. @ line 91, column 21

It is highly recommended to fix these problems because they threaten the stability of your build.

For this reason, future Maven versions might no longer support building such malformed projects.`

I copied the versions from TLS-Attacker, but we should consider updating to the pluginversions 2.20.