### PR TITLE
Fix Padding Oracle Probe result

### DIFF
--- a/TLS-Server-Scanner/src/main/java/de/rub/nds/tlsscanner/serverscanner/probe/PaddingOracleProbe.java
+++ b/TLS-Server-Scanner/src/main/java/de/rub/nds/tlsscanner/serverscanner/probe/PaddingOracleProbe.java
@@ -81,10 +81,10 @@ public class PaddingOracleProbe extends TlsProbe {
                 }
                 LOGGER.debug("Finished non-determinism evaluation");
             }
-            return new PaddingOracleResult(testResultList);
+            return new PaddingOracleResult(testResultList, TestResult.TRUE);
         } catch (Exception e) {
             LOGGER.error("Could not scan for " + getProbeName(), e);
-            return new PaddingOracleResult(null);
+            return new PaddingOracleResult(null,TestResult.ERROR_DURING_TEST);
         }
     }
 
@@ -163,7 +163,7 @@ public class PaddingOracleProbe extends TlsProbe {
 
     @Override
     public ProbeResult getCouldNotExecuteResult() {
-        return new PaddingOracleResult(null);
+        return new PaddingOracleResult(null, TestResult.COULD_NOT_TEST);
     }
 
     private void extendFingerPrint(InformationLeakTest<PaddingOracleTestInfo> informationLeakTest,

--- a/TLS-Server-Scanner/src/main/java/de/rub/nds/tlsscanner/serverscanner/report/result/PaddingOracleResult.java
+++ b/TLS-Server-Scanner/src/main/java/de/rub/nds/tlsscanner/serverscanner/report/result/PaddingOracleResult.java
@@ -31,18 +31,23 @@ public class PaddingOracleResult extends ProbeResult {
 
     private TestResult vulnerable;
 
-    public PaddingOracleResult(List<InformationLeakTest<PaddingOracleTestInfo>> resultList) {
+    public PaddingOracleResult(List<InformationLeakTest<PaddingOracleTestInfo>> resultList, TestResult vulnerable) {
         super(ProbeType.PADDING_ORACLE);
         this.resultList = resultList;
         if (this.resultList != null) {
-            vulnerable = TestResult.FALSE;
+            this.vulnerable = TestResult.FALSE;
             for (InformationLeakTest informationLeakTest : resultList) {
                 if (informationLeakTest.isSignificantDistinctAnswers()) {
-                    vulnerable = TestResult.TRUE;
+                    this.vulnerable = TestResult.TRUE;
                 }
             }
         } else {
-            vulnerable = TestResult.ERROR_DURING_TEST;
+            /*Check if it had failed because it could not execute the task, eg: no block ciphers supported*/
+            if (vulnerable == TestResult.COULD_NOT_TEST)
+                this.vulnerable = TestResult.COULD_NOT_TEST;
+            else
+                this.vulnerable = TestResult.ERROR_DURING_TEST;
+
         }
     }
 


### PR DESCRIPTION
Report "could not test (not vulnerable)" instead of "error" in Padding Oracle Probe if it could not execute the probe. I've noticed this bug while testing against a server configured not to have block ciphers available and the tool would report "error", instead of not being vulnerable.