### PR TITLE
fix: HSTS header case issue with HTTP/2

### DIFF
--- a/TLS-Server-Scanner/src/main/java/de/rub/nds/tlsscanner/serverscanner/probe/result/HttpHeaderResult.java
+++ b/TLS-Server-Scanner/src/main/java/de/rub/nds/tlsscanner/serverscanner/probe/result/HttpHeaderResult.java
@@ -55,7 +55,7 @@ public class HttpHeaderResult extends ProbeResult<ServerReport> {
         List<HpkpPin> reportOnlyPinList = new LinkedList<>();
         if (headerList != null) {
             for (HttpsHeader header : headerList) {
-                if (header.getHeaderName().getValue().equals("Strict-Transport-Security")) {
+                if (header.getHeaderName().getValue().toLowerCase().equals("strict-transport-security")) {
                     supportsHsts = TestResults.TRUE;
                     boolean preload = false;
                     String[] values = header.getHeaderValue().getValue().split(";");


### PR DESCRIPTION
HTTP/2 headers are lower-case.

When scanning www.bundestag.de the tool reports:
"HSTS is disabled. Enable HSTS"

However, the header is set:
`$ curl -s https://www.bundestag.de -D - | grep strict-transport-security
strict-transport-security: max-age=31536000
`

This patch fixes it. There might be a lot more issues like this in the code, however... 