### PR TITLE
Simplified Dockerfile by Aligning Dockerfile to the Compiling Instructions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,23 +1,10 @@
-FROM maven:3.6.1-jdk-11 AS build-image
+FROM maven:3.8.6-jdk-11 AS build-image
 WORKDIR /build
-RUN git clone https://github.com/RUB-NDS/ModifiableVariable.git 
-RUN git clone https://github.com/RUB-NDS/ASN.1-Tool.git
-RUN git clone https://github.com/RUB-NDS/X509-Attacker.git
-RUN git clone https://github.com/RUB-NDS/TLS-Attacker.git
-RUN git clone https://github.com/RUB-NDS/TLS-Scanner.git --recurse-submodules
-WORKDIR /build/ModifiableVariable
-RUN git checkout tags/3.5.0
-RUN mvn clean install -DskipTests=true
-WORKDIR /build/ASN.1-Tool
-RUN mvn clean install -DskipTests=true
-WORKDIR /build/X509-Attacker
-RUN mvn clean install -DskipTests=true
-
-WORKDIR /build/TLS-Attacker
-RUN mvn clean install -DskipTests=true
+RUN git clone https://github.com/RUB-NDS/TLS-Scanner.git
 
 WORKDIR /build/TLS-Scanner
-RUN mvn clean install -DskipTests=true
+RUN git submodule update --init --recursive
+RUN mvn clean package
 
 #############
 FROM openjdk:11
@@ -26,4 +13,3 @@ COPY --from=build-image /build/TLS-Scanner/apps /apps
 
 WORKDIR /apps
 ENTRYPOINT ["java", "-jar", "TLS-Server-Scanner.jar"]
-


### PR DESCRIPTION
Aligned Dockerfile to the Compiling Instructions (https://github.com/tls-attacker/TLS-Scanner?tab=readme-ov-file#compiling). This fixed errors thrown by other Tools which were installed before this (https://github.com/tls-attacker/TLS-Scanner/issues/104)

Also updated the maven docker image.