### PR TITLE
Add command line option to track probes via TLS debug extension

### DIFF
--- a/TLS-Scanner-Core/src/main/java/de/rub/nds/tlsscanner/core/config/TlsScannerConfig.java
+++ b/TLS-Scanner-Core/src/main/java/de/rub/nds/tlsscanner/core/config/TlsScannerConfig.java
@@ -16,6 +16,7 @@ import de.rub.nds.tlsattacker.core.config.delegate.GeneralDelegate;
 import de.rub.nds.tlsattacker.core.config.delegate.QuicDelegate;
 import de.rub.nds.tlsattacker.core.config.delegate.StarttlsDelegate;
 import de.rub.nds.tlsscanner.core.config.delegate.CallbackDelegate;
+import de.rub.nds.tlsscanner.core.config.delegate.DebugExtensionDelegate;
 import de.rub.nds.tlsscanner.core.config.delegate.DtlsDelegate;
 
 public class TlsScannerConfig extends TLSDelegateConfig {
@@ -34,6 +35,8 @@ public class TlsScannerConfig extends TLSDelegateConfig {
 
     @ParametersDelegate private CallbackDelegate callbackDelegate;
 
+    @ParametersDelegate private DebugExtensionDelegate debugExtensionDelegate;
+
     @ParametersDelegate private ExecutorConfig executorConfig;
 
     public TlsScannerConfig(GeneralDelegate delegate) {
@@ -43,12 +46,14 @@ public class TlsScannerConfig extends TLSDelegateConfig {
         this.quicDelegate = new QuicDelegate();
         this.startTlsDelegate = new StarttlsDelegate();
         this.callbackDelegate = new CallbackDelegate();
+        this.debugExtensionDelegate = new DebugExtensionDelegate();
         this.executorConfig = new ExecutorConfig();
 
         addDelegate(dtlsDelegate);
         addDelegate(quicDelegate);
         addDelegate(startTlsDelegate);
         addDelegate(callbackDelegate);
+        addDelegate(debugExtensionDelegate);
     }
 
     public DtlsDelegate getDtlsDelegate() {
@@ -65,6 +70,10 @@ public class TlsScannerConfig extends TLSDelegateConfig {
 
     public CallbackDelegate getCallbackDelegate() {
         return callbackDelegate;
+    }
+
+    public DebugExtensionDelegate getDebugExtensionDelegate() {
+        return debugExtensionDelegate;
     }
 
     public ExecutorConfig getExecutorConfig() {

--- a/TLS-Scanner-Core/src/main/java/de/rub/nds/tlsscanner/core/config/delegate/CallbackDelegate.java
+++ b/TLS-Scanner-Core/src/main/java/de/rub/nds/tlsscanner/core/config/delegate/CallbackDelegate.java
@@ -15,8 +15,11 @@ import de.rub.nds.tlsattacker.core.exceptions.ConfigurationException;
 import de.rub.nds.tlsattacker.core.state.State;
 import java.io.IOException;
 import java.util.function.Function;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 public class CallbackDelegate extends Delegate {
+    private static final Logger LOGGER = LogManager.getLogger();
 
     @Parameter(
             names = "-beforeTransportPreInitCb",

--- a/TLS-Scanner-Core/src/main/java/de/rub/nds/tlsscanner/core/config/delegate/DebugExtensionDelegate.java
+++ b/TLS-Scanner-Core/src/main/java/de/rub/nds/tlsscanner/core/config/delegate/DebugExtensionDelegate.java
@@ -19,13 +19,22 @@ public class DebugExtensionDelegate extends Delegate {
             names = "-debugExtension",
             required = false,
             description = "TLS-Attacker debug extension")
-    private String debugExtension = "TLS-Attacker debug extension";
+    private Boolean debugExtension = false;
+
+    public boolean isDebugExtension() {
+        return debugExtension;
+    }
+
+    public void setDebugExtension(boolean debugExtension) {
+        this.debugExtension = debugExtension;
+    }
 
     public DebugExtensionDelegate() {}
 
     @Override
     public void applyDelegate(Config config) throws ConfigurationException {
-        config.setAddDebugExtension(true);
-        config.setDefaultDebugContent(debugExtension);
+        if (debugExtension) {
+            config.setAddDebugExtension(true);
+        }
     }
 }

--- a/TLS-Scanner-Core/src/main/java/de/rub/nds/tlsscanner/core/config/delegate/DebugExtensionDelegate.java
+++ b/TLS-Scanner-Core/src/main/java/de/rub/nds/tlsscanner/core/config/delegate/DebugExtensionDelegate.java
@@ -1,0 +1,31 @@
+/*
+ * TLS-Scanner - A TLS configuration and analysis tool based on TLS-Attacker
+ *
+ * Copyright 2017-2023 Ruhr University Bochum, Paderborn University, Technology Innovation Institute, and Hackmanit GmbH
+ *
+ * Licensed under Apache License, Version 2.0
+ * http://www.apache.org/licenses/LICENSE-2.0.txt
+ */
+package de.rub.nds.tlsscanner.core.config.delegate;
+
+import com.beust.jcommander.Parameter;
+import de.rub.nds.tlsattacker.core.config.Config;
+import de.rub.nds.tlsattacker.core.config.delegate.Delegate;
+import de.rub.nds.tlsattacker.core.exceptions.ConfigurationException;
+
+public class DebugExtensionDelegate extends Delegate {
+
+    @Parameter(
+            names = "-debugExtension",
+            required = false,
+            description = "TLS-Attacker debug extension")
+    private String debugExtension = "TLS-Attacker debug extension";
+
+    public DebugExtensionDelegate() {}
+
+    @Override
+    public void applyDelegate(Config config) throws ConfigurationException {
+        config.setAddDebugExtension(true);
+        config.setDefaultDebugContent(debugExtension);
+    }
+}

--- a/TLS-Scanner-Core/src/main/java/de/rub/nds/tlsscanner/core/probe/TlsProbe.java
+++ b/TLS-Scanner-Core/src/main/java/de/rub/nds/tlsscanner/core/probe/TlsProbe.java
@@ -33,6 +33,9 @@ public abstract class TlsProbe<ReportT extends TlsScanReport> extends ScannerPro
     }
 
     public final void executeState(Iterable<State> states) {
+        for (State state : states) {
+            state.getContext().getConfig().setDefaultDebugContent(this.getClass().getSimpleName());
+        }
         parallelExecutor.bulkExecuteStateTasks(states);
         extractStats(states);
     }

--- a/TLS-Scanner-Core/src/test/java/de/rub/nds/tlsscanner/core/config/delegate/DebugExtensionDelegateTest.java
+++ b/TLS-Scanner-Core/src/test/java/de/rub/nds/tlsscanner/core/config/delegate/DebugExtensionDelegateTest.java
@@ -8,12 +8,36 @@
  */
 package de.rub.nds.tlsscanner.core.config.delegate;
 
-import org.junit.jupiter.api.Test;
+import de.rub.nds.tlsattacker.core.config.Config;
+import de.rub.nds.tlsattacker.core.exceptions.ConfigurationException;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
 
 public class DebugExtensionDelegateTest {
-    @Test
-    void testApplyDelegate() {
-        // check if the config selector add the debug extension correclty
 
+    private Config mockConfig;
+    private DebugExtensionDelegate delegate;
+
+    @Before
+    public void setUp() {
+        mockConfig = Mockito.mock(Config.class);
+        delegate = new DebugExtensionDelegate();
+    }
+
+    @Test
+    public void testApplyDelegate_whenEnabled_shouldAddDebugExtension()
+            throws ConfigurationException {
+        delegate.setDebugExtension(true);
+        delegate.applyDelegate(mockConfig);
+        Mockito.verify(mockConfig).setAddDebugExtension(true);
+    }
+
+    @Test
+    public void testApplyDelegate_whenDisabled_shouldNotAddDebugExtension()
+            throws ConfigurationException {
+        delegate.setDebugExtension(false);
+        delegate.applyDelegate(mockConfig);
+        Mockito.verify(mockConfig, Mockito.never()).setAddDebugExtension(true);
     }
 }

--- a/TLS-Scanner-Core/src/test/java/de/rub/nds/tlsscanner/core/config/delegate/DebugExtensionDelegateTest.java
+++ b/TLS-Scanner-Core/src/test/java/de/rub/nds/tlsscanner/core/config/delegate/DebugExtensionDelegateTest.java
@@ -1,0 +1,19 @@
+/*
+ * TLS-Scanner - A TLS configuration and analysis tool based on TLS-Attacker
+ *
+ * Copyright 2017-2023 Ruhr University Bochum, Paderborn University, Technology Innovation Institute, and Hackmanit GmbH
+ *
+ * Licensed under Apache License, Version 2.0
+ * http://www.apache.org/licenses/LICENSE-2.0.txt
+ */
+package de.rub.nds.tlsscanner.core.config.delegate;
+
+import org.junit.jupiter.api.Test;
+
+public class DebugExtensionDelegateTest {
+    @Test
+    void testApplyDelegate() {
+        // check if the config selector add the debug extension correclty
+
+    }
+}

--- a/TLS-Server-Scanner/src/main/java/de/rub/nds/tlsscanner/serverscanner/probe/HelloRetryProbe.java
+++ b/TLS-Server-Scanner/src/main/java/de/rub/nds/tlsscanner/serverscanner/probe/HelloRetryProbe.java
@@ -75,7 +75,7 @@ public class HelloRetryProbe extends TlsServerProbe {
                                 WorkflowTraceResultUtil.getFirstReceivedMessage(
                                         state.getWorkflowTrace(),
                                         HandshakeMessageType.SERVER_HELLO))
-                        .isTls13HelloRetryRequest()) {
+                        .isHelloRetryRequest()) {
             sendsHelloRetryRequest = TestResults.TRUE;
             serversChosenGroup = state.getTlsContext().getSelectedGroup();
             if (((ServerHelloMessage)

--- a/TLS-Server-Scanner/src/main/java/de/rub/nds/tlsscanner/serverscanner/selector/ConfigSelector.java
+++ b/TLS-Server-Scanner/src/main/java/de/rub/nds/tlsscanner/serverscanner/selector/ConfigSelector.java
@@ -73,9 +73,6 @@ public class ConfigSelector {
         if (!scannerConfig.getDtlsDelegate().isDTLS()) {
             findWorkingTls13Config();
         }
-        if (scannerConfig.getDebugExtensionDelegate() != null) {
-            scannerConfig.getDebugExtensionDelegate().applyDelegate(workingConfig);
-        }
         return workingConfig != null || workingTl13Config != null;
     }
 

--- a/TLS-Server-Scanner/src/main/java/de/rub/nds/tlsscanner/serverscanner/selector/ConfigSelector.java
+++ b/TLS-Server-Scanner/src/main/java/de/rub/nds/tlsscanner/serverscanner/selector/ConfigSelector.java
@@ -73,6 +73,9 @@ public class ConfigSelector {
         if (!scannerConfig.getDtlsDelegate().isDTLS()) {
             findWorkingTls13Config();
         }
+        if (scannerConfig.getDebugExtensionDelegate() != null) {
+            scannerConfig.getDebugExtensionDelegate().applyDelegate(workingConfig);
+        }
         return workingConfig != null || workingTl13Config != null;
     }
 
@@ -138,7 +141,7 @@ public class ConfigSelector {
 
     public void prepareBaseConfig(Config baseConfig) throws ConfigurationException {
         applyDelegates(baseConfig);
-        applyPerformanceParamters(baseConfig);
+        applyPerformanceParameters(baseConfig);
         applyScannerConfigParameters(baseConfig);
         repairSni(baseConfig);
         repairConfig(baseConfig);
@@ -177,7 +180,7 @@ public class ConfigSelector {
         return trace.executedAsPlanned();
     }
 
-    private void applyPerformanceParamters(Config config) {
+    private void applyPerformanceParameters(Config config) {
         config.setStopReceivingAfterFatal(true);
         config.setStopActionsAfterFatal(true);
         config.setStopActionsAfterIOException(true);

--- a/pom.xml
+++ b/pom.xml
@@ -63,7 +63,7 @@
         <skip.surefire.tests>${skipTests}</skip.surefire.tests>
         <skip.failsafe.tests>${skipTests}</skip.failsafe.tests>
         <!-- Set TLS-Attacker version once -->
-        <toolkit.tls.attacker.version>7.1.1</toolkit.tls.attacker.version>
+        <toolkit.tls.attacker.version>7.2.2-SNAPSHOT</toolkit.tls.attacker.version>
     </properties>
 
     <!-- Override dependency versions from BOM for all submodules to match parent version -->


### PR DESCRIPTION
This PR adds the ability to track which scanner probe is being executed using the TLS debug extension. When enabled with the -debugExtension flag, the scanner automatically sets the debug extension content to the current probe's class name, making it easier to identify which probe is responsible for each connection in packet captures or logs.