### PR TITLE
Add recommended fields to JSON output for guideline checks

### DIFF
--- a/TLS-Server-Scanner/src/main/java/de/rub/nds/tlsscanner/serverscanner/guideline/checks/CipherSuiteGuidelineCheck.java
+++ b/TLS-Server-Scanner/src/main/java/de/rub/nds/tlsscanner/serverscanner/guideline/checks/CipherSuiteGuidelineCheck.java
@@ -64,7 +64,10 @@ public class CipherSuiteGuidelineCheck extends GuidelineCheck<ServerReport> {
     public GuidelineCheckResult evaluate(ServerReport report) {
         List<CipherSuite> nonRecommended = this.nonRecommendedSuites(report);
         return new CipherSuiteGuidelineCheckResult(
-                getName(), GuidelineAdherence.of(nonRecommended.isEmpty()), nonRecommended);
+                getName(),
+                GuidelineAdherence.of(nonRecommended.isEmpty()),
+                nonRecommended,
+                recommendedCipherSuites);
     }
 
     @Override

--- a/TLS-Server-Scanner/src/main/java/de/rub/nds/tlsscanner/serverscanner/guideline/checks/HashAlgorithmsGuidelineCheck.java
+++ b/TLS-Server-Scanner/src/main/java/de/rub/nds/tlsscanner/serverscanner/guideline/checks/HashAlgorithmsGuidelineCheck.java
@@ -64,10 +64,16 @@ public class HashAlgorithmsGuidelineCheck extends GuidelineCheck<ServerReport> {
                 }
             }
             return new HashAlgorithmsGuidelineCheckResult(
-                    getName(), GuidelineAdherence.of(nonRecommended.isEmpty()), nonRecommended);
+                    getName(),
+                    GuidelineAdherence.of(nonRecommended.isEmpty()),
+                    nonRecommended,
+                    recommendedAlgorithms);
         } else {
             return new HashAlgorithmsGuidelineCheckResult(
-                    getName(), GuidelineAdherence.CHECK_FAILED, Collections.emptySet());
+                    getName(),
+                    GuidelineAdherence.CHECK_FAILED,
+                    Collections.emptySet(),
+                    recommendedAlgorithms);
         }
     }
 

--- a/TLS-Server-Scanner/src/main/java/de/rub/nds/tlsscanner/serverscanner/guideline/checks/NamedGroupsGuidelineCheck.java
+++ b/TLS-Server-Scanner/src/main/java/de/rub/nds/tlsscanner/serverscanner/guideline/checks/NamedGroupsGuidelineCheck.java
@@ -103,7 +103,7 @@ public class NamedGroupsGuidelineCheck extends GuidelineCheck<ServerReport> {
             return new NamedGroupsGuidelineCheckResult(getName(), GuidelineAdherence.ADHERED);
         } else {
             return new NamedGroupsGuidelineCheckResult(
-                    getName(), GuidelineAdherence.VIOLATED, nonRecommended);
+                    getName(), GuidelineAdherence.VIOLATED, nonRecommended, recommendedGroups);
         }
     }
 

--- a/TLS-Server-Scanner/src/main/java/de/rub/nds/tlsscanner/serverscanner/guideline/checks/SignatureAlgorithmsGuidelineCheck.java
+++ b/TLS-Server-Scanner/src/main/java/de/rub/nds/tlsscanner/serverscanner/guideline/checks/SignatureAlgorithmsGuidelineCheck.java
@@ -63,10 +63,13 @@ public class SignatureAlgorithmsGuidelineCheck extends GuidelineCheck<ServerRepo
                 }
             }
             return new SignatureAlgorithmsGuidelineCheckResult(
-                    getName(), GuidelineAdherence.of(notRecommended.isEmpty()), notRecommended);
+                    getName(),
+                    GuidelineAdherence.of(notRecommended.isEmpty()),
+                    notRecommended,
+                    recommendedAlgorithms);
         } else {
             return new SignatureAlgorithmsGuidelineCheckResult(
-                    getName(), GuidelineAdherence.CHECK_FAILED, null);
+                    getName(), GuidelineAdherence.CHECK_FAILED, null, recommendedAlgorithms);
         }
     }
 

--- a/TLS-Server-Scanner/src/main/java/de/rub/nds/tlsscanner/serverscanner/guideline/checks/SignatureAndHashAlgorithmsCertificateGuidelineCheck.java
+++ b/TLS-Server-Scanner/src/main/java/de/rub/nds/tlsscanner/serverscanner/guideline/checks/SignatureAndHashAlgorithmsCertificateGuidelineCheck.java
@@ -60,7 +60,10 @@ public class SignatureAndHashAlgorithmsCertificateGuidelineCheck
             }
         }
         return new X509SignatureAlgorithmGuidelineCheckResult(
-                getName(), GuidelineAdherence.of(nonRecommended.isEmpty()), nonRecommended);
+                getName(),
+                GuidelineAdherence.of(nonRecommended.isEmpty()),
+                nonRecommended,
+                recommendedAlgorithms);
     }
 
     @Override

--- a/TLS-Server-Scanner/src/main/java/de/rub/nds/tlsscanner/serverscanner/guideline/checks/SignatureAndHashAlgorithmsGuidelineCheck.java
+++ b/TLS-Server-Scanner/src/main/java/de/rub/nds/tlsscanner/serverscanner/guideline/checks/SignatureAndHashAlgorithmsGuidelineCheck.java
@@ -88,7 +88,7 @@ public class SignatureAndHashAlgorithmsGuidelineCheck extends GuidelineCheck<Ser
         }
         if (algorithms == null || algorithms.isEmpty()) {
             return new SignatureAndHashAlgorithmsCertificateGuidelineCheckResult(
-                    getName(), GuidelineAdherence.CHECK_FAILED, null);
+                    getName(), GuidelineAdherence.CHECK_FAILED, null, recommendedAlgorithms);
         }
         Set<SignatureAndHashAlgorithm> notRecommended = new HashSet<>();
         for (SignatureAndHashAlgorithm alg : algorithms) {
@@ -96,9 +96,11 @@ public class SignatureAndHashAlgorithmsGuidelineCheck extends GuidelineCheck<Ser
                 notRecommended.add(alg);
             }
         }
-        return new SignatureAndHashAlgorithmsCertificateGuidelineCheckResult( // TODO this needs to
-                // be a new result now
-                getName(), GuidelineAdherence.of(notRecommended.isEmpty()), notRecommended);
+        return new SignatureAndHashAlgorithmsCertificateGuidelineCheckResult(
+                getName(),
+                GuidelineAdherence.of(notRecommended.isEmpty()),
+                notRecommended,
+                recommendedAlgorithms);
     }
 
     @Override

--- a/TLS-Server-Scanner/src/main/java/de/rub/nds/tlsscanner/serverscanner/guideline/results/CipherSuiteGuidelineCheckResult.java
+++ b/TLS-Server-Scanner/src/main/java/de/rub/nds/tlsscanner/serverscanner/guideline/results/CipherSuiteGuidelineCheckResult.java
@@ -17,6 +17,7 @@ import java.util.List;
 public class CipherSuiteGuidelineCheckResult extends GuidelineCheckResult {
 
     private final List<CipherSuite> notRecommendedSuites;
+    private final List<CipherSuite> recommendedSuites;
 
     public CipherSuiteGuidelineCheckResult(
             String checkName,
@@ -24,6 +25,17 @@ public class CipherSuiteGuidelineCheckResult extends GuidelineCheckResult {
             List<CipherSuite> notRecommendedSuites) {
         super(checkName, adherence);
         this.notRecommendedSuites = notRecommendedSuites;
+        this.recommendedSuites = null;
+    }
+
+    public CipherSuiteGuidelineCheckResult(
+            String checkName,
+            GuidelineAdherence adherence,
+            List<CipherSuite> notRecommendedSuites,
+            List<CipherSuite> recommendedSuites) {
+        super(checkName, adherence);
+        this.notRecommendedSuites = notRecommendedSuites;
+        this.recommendedSuites = recommendedSuites;
     }
 
     @Override
@@ -38,5 +50,9 @@ public class CipherSuiteGuidelineCheckResult extends GuidelineCheckResult {
 
     public List<CipherSuite> getNotRecommendedSuites() {
         return notRecommendedSuites;
+    }
+
+    public List<CipherSuite> getRecommendedSuites() {
+        return recommendedSuites;
     }
 }

--- a/TLS-Server-Scanner/src/main/java/de/rub/nds/tlsscanner/serverscanner/guideline/results/HashAlgorithmsGuidelineCheckResult.java
+++ b/TLS-Server-Scanner/src/main/java/de/rub/nds/tlsscanner/serverscanner/guideline/results/HashAlgorithmsGuidelineCheckResult.java
@@ -12,12 +12,14 @@ import com.google.common.base.Joiner;
 import de.rub.nds.protocol.constants.HashAlgorithm;
 import de.rub.nds.scanner.core.guideline.GuidelineAdherence;
 import de.rub.nds.scanner.core.guideline.GuidelineCheckResult;
+import java.util.List;
 import java.util.Objects;
 import java.util.Set;
 
 public class HashAlgorithmsGuidelineCheckResult extends GuidelineCheckResult {
 
     private final Set<HashAlgorithm> notRecommendedAlgorithms;
+    private final List<HashAlgorithm> recommendedAlgorithms;
 
     public HashAlgorithmsGuidelineCheckResult(
             String checkName,
@@ -25,6 +27,17 @@ public class HashAlgorithmsGuidelineCheckResult extends GuidelineCheckResult {
             Set<HashAlgorithm> notRecommendedAlgorithms) {
         super(checkName, adherence);
         this.notRecommendedAlgorithms = notRecommendedAlgorithms;
+        this.recommendedAlgorithms = null;
+    }
+
+    public HashAlgorithmsGuidelineCheckResult(
+            String checkName,
+            GuidelineAdherence adherence,
+            Set<HashAlgorithm> notRecommendedAlgorithms,
+            List<HashAlgorithm> recommendedAlgorithms) {
+        super(checkName, adherence);
+        this.notRecommendedAlgorithms = notRecommendedAlgorithms;
+        this.recommendedAlgorithms = recommendedAlgorithms;
     }
 
     @Override
@@ -42,5 +55,9 @@ public class HashAlgorithmsGuidelineCheckResult extends GuidelineCheckResult {
 
     public Set<HashAlgorithm> getNotRecommendedAlgorithms() {
         return notRecommendedAlgorithms;
+    }
+
+    public List<HashAlgorithm> getRecommendedAlgorithms() {
+        return recommendedAlgorithms;
     }
 }

--- a/TLS-Server-Scanner/src/main/java/de/rub/nds/tlsscanner/serverscanner/guideline/results/NamedGroupsGuidelineCheckResult.java
+++ b/TLS-Server-Scanner/src/main/java/de/rub/nds/tlsscanner/serverscanner/guideline/results/NamedGroupsGuidelineCheckResult.java
@@ -21,6 +21,7 @@ public class NamedGroupsGuidelineCheckResult extends GuidelineCheckResult {
     private Set<NamedGroup> notRecommendedGroups;
     private List<NamedGroup> missingRequired;
     private Integer groupCount;
+    private List<NamedGroup> recommendedGroups;
 
     public NamedGroupsGuidelineCheckResult(String checkName, GuidelineAdherence adherence) {
         super(checkName, adherence);
@@ -30,6 +31,16 @@ public class NamedGroupsGuidelineCheckResult extends GuidelineCheckResult {
             String checkName, GuidelineAdherence adherence, Set<NamedGroup> notRecommendedGroups) {
         super(checkName, adherence);
         this.notRecommendedGroups = notRecommendedGroups;
+    }
+
+    public NamedGroupsGuidelineCheckResult(
+            String checkName,
+            GuidelineAdherence adherence,
+            Set<NamedGroup> notRecommendedGroups,
+            List<NamedGroup> recommendedGroups) {
+        super(checkName, adherence);
+        this.notRecommendedGroups = notRecommendedGroups;
+        this.recommendedGroups = recommendedGroups;
     }
 
     public NamedGroupsGuidelineCheckResult(
@@ -76,5 +87,9 @@ public class NamedGroupsGuidelineCheckResult extends GuidelineCheckResult {
 
     public Integer getGroupCount() {
         return groupCount;
+    }
+
+    public List<NamedGroup> getRecommendedGroups() {
+        return recommendedGroups;
     }
 }

--- a/TLS-Server-Scanner/src/main/java/de/rub/nds/tlsscanner/serverscanner/guideline/results/SignatureAlgorithmsGuidelineCheckResult.java
+++ b/TLS-Server-Scanner/src/main/java/de/rub/nds/tlsscanner/serverscanner/guideline/results/SignatureAlgorithmsGuidelineCheckResult.java
@@ -12,12 +12,14 @@ import com.google.common.base.Joiner;
 import de.rub.nds.protocol.constants.SignatureAlgorithm;
 import de.rub.nds.scanner.core.guideline.GuidelineAdherence;
 import de.rub.nds.scanner.core.guideline.GuidelineCheckResult;
+import java.util.List;
 import java.util.Objects;
 import java.util.Set;
 
 public class SignatureAlgorithmsGuidelineCheckResult extends GuidelineCheckResult {
 
     private final Set<SignatureAlgorithm> notRecommendedAlgorithms;
+    private final List<SignatureAlgorithm> recommendedAlgorithms;
 
     public SignatureAlgorithmsGuidelineCheckResult(
             String checkName,
@@ -25,6 +27,17 @@ public class SignatureAlgorithmsGuidelineCheckResult extends GuidelineCheckResul
             Set<SignatureAlgorithm> notRecommendedAlgorithms) {
         super(checkName, adherence);
         this.notRecommendedAlgorithms = notRecommendedAlgorithms;
+        this.recommendedAlgorithms = null;
+    }
+
+    public SignatureAlgorithmsGuidelineCheckResult(
+            String checkName,
+            GuidelineAdherence adherence,
+            Set<SignatureAlgorithm> notRecommendedAlgorithms,
+            List<SignatureAlgorithm> recommendedAlgorithms) {
+        super(checkName, adherence);
+        this.notRecommendedAlgorithms = notRecommendedAlgorithms;
+        this.recommendedAlgorithms = recommendedAlgorithms;
     }
 
     @Override
@@ -42,5 +55,9 @@ public class SignatureAlgorithmsGuidelineCheckResult extends GuidelineCheckResul
 
     public Set<SignatureAlgorithm> getNotRecommendedAlgorithms() {
         return notRecommendedAlgorithms;
+    }
+
+    public List<SignatureAlgorithm> getRecommendedAlgorithms() {
+        return recommendedAlgorithms;
     }
 }

--- a/TLS-Server-Scanner/src/main/java/de/rub/nds/tlsscanner/serverscanner/guideline/results/SignatureAndHashAlgorithmsCertificateGuidelineCheckResult.java
+++ b/TLS-Server-Scanner/src/main/java/de/rub/nds/tlsscanner/serverscanner/guideline/results/SignatureAndHashAlgorithmsCertificateGuidelineCheckResult.java
@@ -12,6 +12,7 @@ import com.google.common.base.Joiner;
 import de.rub.nds.scanner.core.guideline.GuidelineAdherence;
 import de.rub.nds.scanner.core.guideline.GuidelineCheckResult;
 import de.rub.nds.tlsattacker.core.constants.SignatureAndHashAlgorithm;
+import java.util.List;
 import java.util.Objects;
 import java.util.Set;
 
@@ -19,6 +20,7 @@ public class SignatureAndHashAlgorithmsCertificateGuidelineCheckResult
         extends GuidelineCheckResult {
 
     private final Set<SignatureAndHashAlgorithm> notRecommendedAlgorithms;
+    private final List<SignatureAndHashAlgorithm> recommendedAlgorithms;
 
     public SignatureAndHashAlgorithmsCertificateGuidelineCheckResult(
             String checkName,
@@ -26,6 +28,17 @@ public class SignatureAndHashAlgorithmsCertificateGuidelineCheckResult
             Set<SignatureAndHashAlgorithm> notRecommendedAlgorithms) {
         super(checkName, adherence);
         this.notRecommendedAlgorithms = notRecommendedAlgorithms;
+        this.recommendedAlgorithms = null;
+    }
+
+    public SignatureAndHashAlgorithmsCertificateGuidelineCheckResult(
+            String checkName,
+            GuidelineAdherence adherence,
+            Set<SignatureAndHashAlgorithm> notRecommendedAlgorithms,
+            List<SignatureAndHashAlgorithm> recommendedAlgorithms) {
+        super(checkName, adherence);
+        this.notRecommendedAlgorithms = notRecommendedAlgorithms;
+        this.recommendedAlgorithms = recommendedAlgorithms;
     }
 
     @Override
@@ -43,5 +56,9 @@ public class SignatureAndHashAlgorithmsCertificateGuidelineCheckResult
 
     public Set<SignatureAndHashAlgorithm> getNotRecommendedAlgorithms() {
         return notRecommendedAlgorithms;
+    }
+
+    public List<SignatureAndHashAlgorithm> getRecommendedAlgorithms() {
+        return recommendedAlgorithms;
     }
 }

--- a/TLS-Server-Scanner/src/main/java/de/rub/nds/tlsscanner/serverscanner/guideline/results/X509SignatureAlgorithmGuidelineCheckResult.java
+++ b/TLS-Server-Scanner/src/main/java/de/rub/nds/tlsscanner/serverscanner/guideline/results/X509SignatureAlgorithmGuidelineCheckResult.java
@@ -12,12 +12,14 @@ import com.google.common.base.Joiner;
 import de.rub.nds.scanner.core.guideline.GuidelineAdherence;
 import de.rub.nds.scanner.core.guideline.GuidelineCheckResult;
 import de.rub.nds.x509attacker.constants.X509SignatureAlgorithm;
+import java.util.List;
 import java.util.Objects;
 import java.util.Set;
 
 public class X509SignatureAlgorithmGuidelineCheckResult extends GuidelineCheckResult {
 
     private final Set<X509SignatureAlgorithm> notRecommendedAlgorithms;
+    private final List<X509SignatureAlgorithm> recommendedAlgorithms;
 
     public X509SignatureAlgorithmGuidelineCheckResult(
             String checkName,
@@ -25,6 +27,17 @@ public class X509SignatureAlgorithmGuidelineCheckResult extends GuidelineCheckRe
             Set<X509SignatureAlgorithm> notRecommendedAlgorithms) {
         super(checkName, adherence);
         this.notRecommendedAlgorithms = notRecommendedAlgorithms;
+        this.recommendedAlgorithms = null;
+    }
+
+    public X509SignatureAlgorithmGuidelineCheckResult(
+            String checkName,
+            GuidelineAdherence adherence,
+            Set<X509SignatureAlgorithm> notRecommendedAlgorithms,
+            List<X509SignatureAlgorithm> recommendedAlgorithms) {
+        super(checkName, adherence);
+        this.notRecommendedAlgorithms = notRecommendedAlgorithms;
+        this.recommendedAlgorithms = recommendedAlgorithms;
     }
 
     @Override
@@ -42,5 +55,9 @@ public class X509SignatureAlgorithmGuidelineCheckResult extends GuidelineCheckRe
 
     public Set<X509SignatureAlgorithm> getNotRecommendedAlgorithms() {
         return notRecommendedAlgorithms;
+    }
+
+    public List<X509SignatureAlgorithm> getRecommendedAlgorithms() {
+        return recommendedAlgorithms;
     }
 }

--- a/TLS-Server-Scanner/src/test/java/de/rub/nds/tlsscanner/serverscanner/guideline/results/CipherSuiteGuidelineCheckResultTest.java
+++ b/TLS-Server-Scanner/src/test/java/de/rub/nds/tlsscanner/serverscanner/guideline/results/CipherSuiteGuidelineCheckResultTest.java
@@ -1,0 +1,56 @@
+/*
+ * TLS-Scanner - A TLS configuration and analysis tool based on TLS-Attacker
+ *
+ * Copyright 2017-2023 Ruhr University Bochum, Paderborn University, Technology Innovation Institute, and Hackmanit GmbH
+ *
+ * Licensed under Apache License, Version 2.0
+ * http://www.apache.org/licenses/LICENSE-2.0.txt
+ */
+package de.rub.nds.tlsscanner.serverscanner.guideline.results;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import de.rub.nds.scanner.core.guideline.GuidelineAdherence;
+import de.rub.nds.tlsattacker.core.constants.CipherSuite;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+public class CipherSuiteGuidelineCheckResultTest {
+
+    @Test
+    public void testRecommendedSuitesField() {
+        List<CipherSuite> recommendedSuites =
+                Arrays.asList(
+                        CipherSuite.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
+                        CipherSuite.TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384);
+        List<CipherSuite> notRecommendedSuites =
+                Collections.singletonList(CipherSuite.TLS_RSA_WITH_AES_128_CBC_SHA);
+
+        CipherSuiteGuidelineCheckResult result =
+                new CipherSuiteGuidelineCheckResult(
+                        "Test Check",
+                        GuidelineAdherence.VIOLATED,
+                        notRecommendedSuites,
+                        recommendedSuites);
+
+        assertEquals(recommendedSuites, result.getRecommendedSuites());
+        assertEquals(notRecommendedSuites, result.getNotRecommendedSuites());
+        assertEquals(GuidelineAdherence.VIOLATED, result.getAdherence());
+    }
+
+    @Test
+    public void testBackwardCompatibility() {
+        List<CipherSuite> notRecommendedSuites =
+                Collections.singletonList(CipherSuite.TLS_RSA_WITH_AES_128_CBC_SHA);
+
+        CipherSuiteGuidelineCheckResult result =
+                new CipherSuiteGuidelineCheckResult(
+                        "Test Check", GuidelineAdherence.VIOLATED, notRecommendedSuites);
+
+        assertNull(result.getRecommendedSuites());
+        assertEquals(notRecommendedSuites, result.getNotRecommendedSuites());
+        assertEquals(GuidelineAdherence.VIOLATED, result.getAdherence());
+    }
+}

--- a/TLS-Server-Scanner/src/test/java/de/rub/nds/tlsscanner/serverscanner/guideline/results/HashAlgorithmsGuidelineCheckResultTest.java
+++ b/TLS-Server-Scanner/src/test/java/de/rub/nds/tlsscanner/serverscanner/guideline/results/HashAlgorithmsGuidelineCheckResultTest.java
@@ -1,0 +1,56 @@
+/*
+ * TLS-Scanner - A TLS configuration and analysis tool based on TLS-Attacker
+ *
+ * Copyright 2017-2023 Ruhr University Bochum, Paderborn University, Technology Innovation Institute, and Hackmanit GmbH
+ *
+ * Licensed under Apache License, Version 2.0
+ * http://www.apache.org/licenses/LICENSE-2.0.txt
+ */
+package de.rub.nds.tlsscanner.serverscanner.guideline.results;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import de.rub.nds.protocol.constants.HashAlgorithm;
+import de.rub.nds.scanner.core.guideline.GuidelineAdherence;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+
+public class HashAlgorithmsGuidelineCheckResultTest {
+
+    @Test
+    public void testRecommendedAlgorithmsField() {
+        List<HashAlgorithm> recommendedAlgorithms =
+                Arrays.asList(HashAlgorithm.SHA256, HashAlgorithm.SHA384);
+        Set<HashAlgorithm> notRecommendedAlgorithms =
+                new HashSet<>(Collections.singletonList(HashAlgorithm.SHA1));
+
+        HashAlgorithmsGuidelineCheckResult result =
+                new HashAlgorithmsGuidelineCheckResult(
+                        "Test Check",
+                        GuidelineAdherence.VIOLATED,
+                        notRecommendedAlgorithms,
+                        recommendedAlgorithms);
+
+        assertEquals(recommendedAlgorithms, result.getRecommendedAlgorithms());
+        assertEquals(notRecommendedAlgorithms, result.getNotRecommendedAlgorithms());
+        assertEquals(GuidelineAdherence.VIOLATED, result.getAdherence());
+    }
+
+    @Test
+    public void testBackwardCompatibility() {
+        Set<HashAlgorithm> notRecommendedAlgorithms =
+                new HashSet<>(Collections.singletonList(HashAlgorithm.SHA1));
+
+        HashAlgorithmsGuidelineCheckResult result =
+                new HashAlgorithmsGuidelineCheckResult(
+                        "Test Check", GuidelineAdherence.VIOLATED, notRecommendedAlgorithms);
+
+        assertNull(result.getRecommendedAlgorithms());
+        assertEquals(notRecommendedAlgorithms, result.getNotRecommendedAlgorithms());
+        assertEquals(GuidelineAdherence.VIOLATED, result.getAdherence());
+    }
+}

--- a/TLS-Server-Scanner/src/test/java/de/rub/nds/tlsscanner/serverscanner/report/GuidelineResultSerializationTest.java
+++ b/TLS-Server-Scanner/src/test/java/de/rub/nds/tlsscanner/serverscanner/report/GuidelineResultSerializationTest.java
@@ -1,0 +1,165 @@
+/*
+ * TLS-Scanner - A TLS configuration and analysis tool based on TLS-Attacker
+ *
+ * Copyright 2017-2023 Ruhr University Bochum, Paderborn University, Technology Innovation Institute, and Hackmanit GmbH
+ *
+ * Licensed under Apache License, Version 2.0
+ * http://www.apache.org/licenses/LICENSE-2.0.txt
+ */
+package de.rub.nds.tlsscanner.serverscanner.report;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility;
+import com.fasterxml.jackson.annotation.PropertyAccessor;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import de.rub.nds.protocol.constants.HashAlgorithm;
+import de.rub.nds.protocol.constants.SignatureAlgorithm;
+import de.rub.nds.scanner.core.guideline.GuidelineAdherence;
+import de.rub.nds.scanner.core.guideline.GuidelineCheckResult;
+import de.rub.nds.scanner.core.guideline.GuidelineReport;
+import de.rub.nds.tlsattacker.core.constants.CipherSuite;
+import de.rub.nds.tlsattacker.core.constants.NamedGroup;
+import de.rub.nds.tlsscanner.serverscanner.guideline.results.CipherSuiteGuidelineCheckResult;
+import de.rub.nds.tlsscanner.serverscanner.guideline.results.HashAlgorithmsGuidelineCheckResult;
+import de.rub.nds.tlsscanner.serverscanner.guideline.results.NamedGroupsGuidelineCheckResult;
+import de.rub.nds.tlsscanner.serverscanner.guideline.results.SignatureAlgorithmsGuidelineCheckResult;
+import java.io.ByteArrayOutputStream;
+import java.util.*;
+import org.junit.jupiter.api.Test;
+
+public class GuidelineResultSerializationTest {
+
+    @Test
+    void testCipherSuiteGuidelineCheckResultSerialization() throws Exception {
+        List<CipherSuite> recommendedSuites =
+                Arrays.asList(
+                        CipherSuite.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
+                        CipherSuite.TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384);
+        List<CipherSuite> notRecommendedSuites =
+                Collections.singletonList(CipherSuite.TLS_RSA_WITH_AES_128_CBC_SHA);
+
+        CipherSuiteGuidelineCheckResult result =
+                new CipherSuiteGuidelineCheckResult(
+                        "BSI TR-02102-2 Cipher Suite Check",
+                        GuidelineAdherence.VIOLATED,
+                        notRecommendedSuites,
+                        recommendedSuites);
+
+        String json = serializeResult(result);
+
+        assertTrue(json.contains("\"recommendedSuites\""));
+        assertTrue(json.contains("\"notRecommendedSuites\""));
+        assertTrue(json.contains("TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256"));
+        assertTrue(json.contains("TLS_RSA_WITH_AES_128_CBC_SHA"));
+    }
+
+    @Test
+    void testHashAlgorithmsGuidelineCheckResultSerialization() throws Exception {
+        List<HashAlgorithm> recommendedAlgorithms =
+                Arrays.asList(HashAlgorithm.SHA256, HashAlgorithm.SHA384);
+        Set<HashAlgorithm> notRecommendedAlgorithms =
+                new HashSet<>(Collections.singletonList(HashAlgorithm.SHA1));
+
+        HashAlgorithmsGuidelineCheckResult result =
+                new HashAlgorithmsGuidelineCheckResult(
+                        "Hash Algorithm Check",
+                        GuidelineAdherence.VIOLATED,
+                        notRecommendedAlgorithms,
+                        recommendedAlgorithms);
+
+        String json = serializeResult(result);
+
+        assertTrue(json.contains("\"recommendedAlgorithms\""));
+        assertTrue(json.contains("\"notRecommendedAlgorithms\""));
+        assertTrue(json.contains("SHA256"));
+        assertTrue(json.contains("SHA1"));
+    }
+
+    @Test
+    void testNamedGroupsGuidelineCheckResultSerialization() throws Exception {
+        List<NamedGroup> recommendedGroups =
+                Arrays.asList(NamedGroup.SECP256R1, NamedGroup.SECP384R1);
+        Set<NamedGroup> notRecommendedGroups =
+                new HashSet<>(Collections.singletonList(NamedGroup.SECP160K1));
+
+        NamedGroupsGuidelineCheckResult result =
+                new NamedGroupsGuidelineCheckResult(
+                        "Named Groups Check",
+                        GuidelineAdherence.VIOLATED,
+                        notRecommendedGroups,
+                        recommendedGroups);
+
+        String json = serializeResult(result);
+
+        assertTrue(json.contains("\"recommendedGroups\""));
+        assertTrue(json.contains("\"notRecommendedGroups\""));
+        assertTrue(json.contains("SECP256R1"));
+        assertTrue(json.contains("SECP160K1"));
+    }
+
+    @Test
+    void testSignatureAlgorithmsGuidelineCheckResultSerialization() throws Exception {
+        List<SignatureAlgorithm> recommendedAlgorithms =
+                Arrays.asList(SignatureAlgorithm.RSA_PKCS1, SignatureAlgorithm.ECDSA);
+        Set<SignatureAlgorithm> notRecommendedAlgorithms =
+                new HashSet<>(Collections.singletonList(SignatureAlgorithm.DSA));
+
+        SignatureAlgorithmsGuidelineCheckResult result =
+                new SignatureAlgorithmsGuidelineCheckResult(
+                        "Signature Algorithm Check",
+                        GuidelineAdherence.VIOLATED,
+                        notRecommendedAlgorithms,
+                        recommendedAlgorithms);
+
+        String json = serializeResult(result);
+
+        assertTrue(json.contains("\"recommendedAlgorithms\""));
+        assertTrue(json.contains("\"notRecommendedAlgorithms\""));
+        assertTrue(json.contains("RSA_PKCS1"));
+        assertTrue(json.contains("DSA"));
+    }
+
+    @Test
+    void testFullGuidelineReportSerialization() throws Exception {
+        List<GuidelineCheckResult> checkResults = new ArrayList<>();
+
+        // Add cipher suite result
+        checkResults.add(
+                new CipherSuiteGuidelineCheckResult(
+                        "Cipher Suite Check",
+                        GuidelineAdherence.VIOLATED,
+                        Collections.singletonList(CipherSuite.TLS_RSA_WITH_AES_128_CBC_SHA),
+                        Arrays.asList(CipherSuite.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256)));
+
+        // Add hash algorithm result
+        checkResults.add(
+                new HashAlgorithmsGuidelineCheckResult(
+                        "Hash Check",
+                        GuidelineAdherence.ADHERED,
+                        Collections.emptySet(),
+                        Arrays.asList(HashAlgorithm.SHA256)));
+
+        GuidelineReport report =
+                new GuidelineReport("BSI TR-02102-2", "https://www.bsi.bund.de/...", checkResults);
+
+        ServerReport serverReport = new ServerReport();
+        serverReport.addGuidelineReport(report);
+
+        ByteArrayOutputStream stream = new ByteArrayOutputStream();
+        ServerReportSerializer.serialize(stream, serverReport);
+        String json = stream.toString();
+
+        assertTrue(json.contains("\"guidelineReports\""));
+        assertTrue(json.contains("\"recommendedSuites\""));
+        assertTrue(json.contains("\"recommendedAlgorithms\""));
+    }
+
+    private String serializeResult(GuidelineCheckResult result) throws Exception {
+        ObjectMapper mapper = new ObjectMapper();
+        mapper.setVisibility(PropertyAccessor.GETTER, Visibility.NONE);
+        mapper.setVisibility(PropertyAccessor.FIELD, Visibility.ANY);
+
+        return mapper.writeValueAsString(result);
+    }
+}


### PR DESCRIPTION
## Summary
- Added `recommended` fields alongside existing `notRecommended` fields in all guideline check results
- Ensures JSON output includes both what is recommended and what is not recommended by BSI and NIST guidelines
- Maintains backward compatibility by using overloaded constructors

## Test plan
- [x] Added unit tests for new constructors in CipherSuiteGuidelineCheckResultTest and HashAlgorithmsGuidelineCheckResultTest  
- [x] Added comprehensive JSON serialization tests in GuidelineResultSerializationTest
- [x] All tests pass (`mvn test`)
- [x] Code formatted with spotless (`mvn spotless:apply`)

## Closes
Fixes #115