### PR TITLE
Fix issue #113: Prevent PaddingOracleAttacker from running endlessly

### DIFF
--- a/TLS-Server-Scanner/src/test/java/de/rub/nds/tlsscanner/serverscanner/probe/PaddingOracleProbeTest.java
+++ b/TLS-Server-Scanner/src/test/java/de/rub/nds/tlsscanner/serverscanner/probe/PaddingOracleProbeTest.java
@@ -1,0 +1,176 @@
+/*
+ * TLS-Scanner - A TLS configuration and analysis tool based on TLS-Attacker
+ *
+ * Copyright 2017-2023 Ruhr University Bochum, Paderborn University, Technology Innovation Institute, and Hackmanit GmbH
+ *
+ * Licensed under Apache License, Version 2.0
+ * http://www.apache.org/licenses/LICENSE-2.0.txt
+ */
+package de.rub.nds.tlsscanner.serverscanner.probe;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import de.rub.nds.scanner.core.config.ScannerDetail;
+import de.rub.nds.scanner.core.probe.result.TestResults;
+import de.rub.nds.tlsattacker.core.config.Config;
+import de.rub.nds.tlsattacker.core.constants.CipherSuite;
+import de.rub.nds.tlsattacker.core.constants.ProtocolVersion;
+import de.rub.nds.tlsattacker.core.workflow.ParallelExecutor;
+import de.rub.nds.tlsscanner.core.constants.TlsAnalyzedProperty;
+import de.rub.nds.tlsscanner.core.leak.PaddingOracleTestInfo;
+import de.rub.nds.tlsscanner.core.probe.result.VersionSuiteListPair;
+import de.rub.nds.tlsscanner.core.vector.statistics.InformationLeakTest;
+import de.rub.nds.tlsscanner.serverscanner.config.ServerScannerConfig;
+import de.rub.nds.tlsscanner.serverscanner.report.ServerReport;
+import de.rub.nds.tlsscanner.serverscanner.selector.ConfigSelector;
+import java.lang.reflect.Field;
+import java.util.Arrays;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+public class PaddingOracleProbeTest {
+
+    private PaddingOracleProbe probe;
+    private ConfigSelector configSelector;
+    private ParallelExecutor executor;
+    private ServerReport report;
+    private ServerScannerConfig scannerConfig;
+
+    @BeforeEach
+    public void setUp() {
+        executor = Mockito.mock(ParallelExecutor.class);
+        Mockito.when(executor.getReexecutions()).thenReturn(1);
+
+        scannerConfig = new ServerScannerConfig();
+        scannerConfig.getExecutorConfig().setScanDetail(ScannerDetail.QUICK);
+
+        configSelector = Mockito.mock(ConfigSelector.class);
+        Mockito.when(configSelector.getScannerConfig()).thenReturn(scannerConfig);
+        Mockito.when(configSelector.getBaseConfig()).thenReturn(Config.createConfig());
+
+        report = new ServerReport();
+
+        probe = new PaddingOracleProbe(configSelector, executor);
+    }
+
+    @Test
+    public void testProbeCreation() {
+        assertNotNull(probe);
+    }
+
+    @Test
+    public void testProbeRequiresBlockCiphers() {
+        ServerReport testReport = new ServerReport();
+        testReport.putResult(TlsAnalyzedProperty.SUPPORTS_BLOCK_CIPHERS, TestResults.FALSE);
+
+        assertFalse(probe.getRequirements().evaluate(testReport));
+
+        testReport.putResult(TlsAnalyzedProperty.SUPPORTS_BLOCK_CIPHERS, TestResults.TRUE);
+        assertTrue(probe.getRequirements().evaluate(testReport));
+    }
+
+    @Test
+    public void testProbeSkipsNonCbcCiphers() {
+        // Prepare report with non-CBC cipher suites
+        VersionSuiteListPair versionPair =
+                new VersionSuiteListPair(
+                        ProtocolVersion.TLS12,
+                        Arrays.asList(
+                                CipherSuite.TLS_RSA_WITH_AES_128_GCM_SHA256, // GCM, not CBC
+                                CipherSuite
+                                        .TLS_DHE_RSA_WITH_CHACHA20_POLY1305_SHA256 // ChaCha20, not
+                                // CBC
+                                ));
+
+        report.setVersionSuitePairs(Arrays.asList(versionPair));
+        probe.adjustConfig(report);
+        probe.executeTest();
+
+        List<InformationLeakTest<PaddingOracleTestInfo>> results =
+                (List<InformationLeakTest<PaddingOracleTestInfo>>) probe.getCouldNotExecuteReason();
+
+        // Should not test any cipher suite as none are CBC
+        assertEquals(0, results != null ? results.size() : 0);
+    }
+
+    @Test
+    public void testProbeTestsCbcCiphers() {
+        // Prepare report with CBC cipher suites
+        VersionSuiteListPair versionPair =
+                new VersionSuiteListPair(
+                        ProtocolVersion.TLS12,
+                        Arrays.asList(
+                                CipherSuite.TLS_RSA_WITH_AES_128_CBC_SHA,
+                                CipherSuite.TLS_RSA_WITH_AES_256_CBC_SHA256));
+
+        report.setVersionSuitePairs(Arrays.asList(versionPair));
+        probe.adjustConfig(report);
+
+        // Mock the executor to avoid actual network calls
+        Mockito.doNothing().when(executor).bulkExecuteTasks(Mockito.anyList());
+
+        // Execute with proper mocking would test CBC ciphers
+        // This test verifies the setup and filtering logic
+        assertDoesNotThrow(() -> probe.executeTest());
+    }
+
+    @Test
+    public void testProbeRespectsMaxRuntime() throws Exception {
+        // Use reflection to verify MAX_PROBE_RUNTIME_MS constant
+        Field maxRuntimeField = PaddingOracleProbe.class.getDeclaredField("MAX_PROBE_RUNTIME_MS");
+        maxRuntimeField.setAccessible(true);
+        long maxRuntime = (long) maxRuntimeField.get(null);
+
+        // 20 minutes = 1200000ms
+        assertEquals(1200000L, maxRuntime);
+    }
+
+    @Test
+    public void testProbeHandlesEmptySuiteList() {
+        report.setVersionSuitePairs(Arrays.asList());
+        probe.adjustConfig(report);
+        probe.executeTest();
+
+        // Should complete without errors
+        assertNotNull(probe.getCouldNotExecuteReason());
+    }
+
+    @Test
+    public void testProbeSkipsTls13() {
+        // TLS 1.3 doesn't use padding oracle vulnerable CBC mode
+        VersionSuiteListPair versionPair =
+                new VersionSuiteListPair(
+                        ProtocolVersion.TLS13, Arrays.asList(CipherSuite.TLS_AES_128_GCM_SHA256));
+
+        report.setVersionSuitePairs(Arrays.asList(versionPair));
+        probe.adjustConfig(report);
+        probe.executeTest();
+
+        List<InformationLeakTest<PaddingOracleTestInfo>> results =
+                (List<InformationLeakTest<PaddingOracleTestInfo>>) probe.getCouldNotExecuteReason();
+
+        // Should not test TLS 1.3
+        assertEquals(0, results != null ? results.size() : 0);
+    }
+
+    @Test
+    public void testProbeSkipsSsl() {
+        // SSL versions are skipped
+        VersionSuiteListPair versionPair =
+                new VersionSuiteListPair(
+                        ProtocolVersion.SSL3,
+                        Arrays.asList(CipherSuite.TLS_RSA_WITH_3DES_EDE_CBC_SHA));
+
+        report.setVersionSuitePairs(Arrays.asList(versionPair));
+        probe.adjustConfig(report);
+        probe.executeTest();
+
+        List<InformationLeakTest<PaddingOracleTestInfo>> results =
+                (List<InformationLeakTest<PaddingOracleTestInfo>>) probe.getCouldNotExecuteReason();
+
+        // Should not test SSL versions
+        assertEquals(0, results != null ? results.size() : 0);
+    }
+}


### PR DESCRIPTION
## Summary
- Add early termination conditions to prevent endless execution when testing unresponsive servers
- Add maximum runtime limit to ensure the probe completes within reasonable time
- Improve error handling to continue testing other cipher suites when individual tests fail

## Fixes #113

This PR addresses the issue where `PaddingOracleAttacker` can run for hours while producing thousands of warnings when testing certain targets.

## Changes Made

### PaddingOracleAttacker.java
- Added `MAX_CONSECUTIVE_FAILURES` constant (20) - stops testing after 20 consecutive fingerprint extraction failures
- Added `MAX_FAILURE_RATE` constant (0.75) - stops testing when more than 75% of attempts fail (after at least 10 attempts)
- Added failure tracking logic in `createVectorResponseList()` method
- Added informative logging about failure statistics

### PaddingOracleProbe.java  
- Added `MAX_PROBE_RUNTIME_MS` constant (20 minutes) - ensures probe completes in reasonable time
- Added runtime checks before processing each cipher suite and during extended evaluation
- Added try-catch blocks to handle individual test failures gracefully without stopping the entire probe

### PaddingOracleProbeTest.java
- Added unit tests for the probe's basic functionality and configuration

## Test Plan
- [x] Code compiles successfully
- [x] Code formatting applied with spotless
- [x] Added unit tests for probe configuration
- [ ] Manual testing with problematic servers (requires access to specific test targets)

## Notes
The fix uses a two-pronged approach:
1. **Failure detection**: Stops early when too many consecutive failures occur or the overall failure rate is too high
2. **Time limit**: Enforces a maximum runtime to prevent the probe from running indefinitely

This ensures the scanner remains responsive even when testing servers with connectivity issues or other problems that prevent successful fingerprint extraction.