### PR TITLE
Fix missing properties in JSON output

### DIFF
--- a/TLS-Server-Scanner/src/main/java/de/rub/nds/tlsscanner/serverscanner/report/ServerReport.java
+++ b/TLS-Server-Scanner/src/main/java/de/rub/nds/tlsscanner/serverscanner/report/ServerReport.java
@@ -20,6 +20,7 @@ import de.rub.nds.scanner.core.probe.result.MapResult;
 import de.rub.nds.scanner.core.probe.result.ObjectResult;
 import de.rub.nds.scanner.core.probe.result.SetResult;
 import de.rub.nds.scanner.core.probe.result.StringResult;
+import de.rub.nds.scanner.core.probe.result.TestResult;
 import de.rub.nds.scanner.core.probe.result.TestResults;
 import de.rub.nds.scanner.core.report.rating.ScoreReport;
 import de.rub.nds.tlsattacker.core.constants.NamedGroup;
@@ -356,5 +357,17 @@ public class ServerReport extends TlsScanReport {
     public synchronized String getIpv6Address() {
         StringResult stringResult = getStringResult(QuicAnalyzedProperty.IPV6_ADDRESS);
         return stringResult == null ? null : stringResult.getValue();
+    }
+
+    public synchronized TestResult getSupportsOcspStapling() {
+        return getResult(TlsAnalyzedProperty.SUPPORTS_OCSP_STAPLING);
+    }
+
+    public synchronized TestResult getIssuesTls13SessionTicketsAfterHandshake() {
+        return getResult(TlsAnalyzedProperty.ISSUES_TLS13_SESSION_TICKETS_AFTER_HANDSHAKE);
+    }
+
+    public synchronized TestResult getIssuesTls13SessionTicketsWithApplicationData() {
+        return getResult(TlsAnalyzedProperty.ISSUES_TLS13_SESSION_TICKETS_WITH_APPLICATION_DATA);
     }
 }

--- a/TLS-Server-Scanner/src/test/java/de/rub/nds/tlsscanner/serverscanner/report/ServerReportSerializerTest.java
+++ b/TLS-Server-Scanner/src/test/java/de/rub/nds/tlsscanner/serverscanner/report/ServerReportSerializerTest.java
@@ -134,4 +134,27 @@ public class ServerReportSerializerTest {
         ServerReportSerializer.serialize(new ByteArrayOutputStream(), report);
         // This should not throw an exception
     }
+
+    @Test
+    void testSerializeOcspAndSessionTicketProperties() {
+        ServerReport report = new ServerReport();
+        report.putResult(TlsAnalyzedProperty.SUPPORTS_OCSP_STAPLING, TestResults.TRUE);
+        report.putResult(
+                TlsAnalyzedProperty.ISSUES_TLS13_SESSION_TICKETS_AFTER_HANDSHAKE, TestResults.TRUE);
+        report.putResult(
+                TlsAnalyzedProperty.ISSUES_TLS13_SESSION_TICKETS_WITH_APPLICATION_DATA,
+                TestResults.FALSE);
+
+        ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+        ServerReportSerializer.serialize(outputStream, report);
+
+        String jsonOutput = outputStream.toString();
+        // Verify that the properties are included in the JSON output
+        assert jsonOutput.contains("SUPPORTS_OCSP_STAPLING")
+                : "JSON doesn't contain SUPPORTS_OCSP_STAPLING";
+        assert jsonOutput.contains("ISSUES_TLS13_SESSION_TICKETS_AFTER_HANDSHAKE")
+                : "JSON doesn't contain ISSUES_TLS13_SESSION_TICKETS_AFTER_HANDSHAKE";
+        assert jsonOutput.contains("ISSUES_TLS13_SESSION_TICKETS_WITH_APPLICATION_DATA")
+                : "JSON doesn't contain ISSUES_TLS13_SESSION_TICKETS_WITH_APPLICATION_DATA";
+    }
 }


### PR DESCRIPTION
## Summary
- Added getter methods to expose SUPPORTS_OCSP_STAPLING and TLS13 session ticket properties in JSON output
- These properties were already being collected but were not visible in the JSON serialization

## Changes
- Added `getSupportsOcspStapling()` method to ServerReport
- Added `getIssuesTls13SessionTicketsAfterHandshake()` method to ServerReport  
- Added `getIssuesTls13SessionTicketsWithApplicationData()` method to ServerReport
- Added test to verify the properties are correctly serialized to JSON

## Test plan
- [x] Added unit test `testSerializeOcspAndSessionTicketProperties` to verify JSON serialization
- [x] Test passes successfully
- [x] Code compiles without errors
- [x] Spotless formatting applied

Fixes #109