### PR TITLE
Create and Use InformationLeakTest.getRareResponses (#371)

### DIFF
--- a/TLS-Scanner-Core/src/test/java/de/rub/nds/tlsscanner/core/vector/statistics/InformationLeakTestTest.java
+++ b/TLS-Scanner-Core/src/test/java/de/rub/nds/tlsscanner/core/vector/statistics/InformationLeakTestTest.java
@@ -1,0 +1,231 @@
+/*
+ * TLS-Scanner - A TLS configuration and analysis tool based on TLS-Attacker
+ *
+ * Copyright 2017-2023 Ruhr University Bochum, Paderborn University, Technology Innovation Institute, and Hackmanit GmbH
+ *
+ * Licensed under Apache License, Version 2.0
+ * http://www.apache.org/licenses/LICENSE-2.0.txt
+ */
+package de.rub.nds.tlsscanner.core.vector.statistics;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import de.rub.nds.tlsattacker.transport.socket.SocketState;
+import de.rub.nds.tlsscanner.core.vector.Vector;
+import de.rub.nds.tlsscanner.core.vector.VectorResponse;
+import de.rub.nds.tlsscanner.core.vector.response.ResponseFingerprint;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+public class InformationLeakTestTest {
+
+    private static class TestVector implements Vector {
+        private final String name;
+
+        public TestVector(String name) {
+            this.name = name;
+        }
+
+        @Override
+        public String getName() {
+            return name;
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (obj instanceof TestVector) {
+                return name.equals(((TestVector) obj).name);
+            }
+            return false;
+        }
+
+        @Override
+        public int hashCode() {
+            return name.hashCode();
+        }
+    }
+
+    private static class SimpleTestInfo extends TestInfo {
+        @Override
+        public String getTechnicalName() {
+            return "SimpleTest";
+        }
+
+        @Override
+        public List<String> getFieldNames() {
+            return List.of();
+        }
+
+        @Override
+        public List<String> getFieldValues() {
+            return List.of();
+        }
+
+        @Override
+        public String getPrintableName() {
+            return "Simple Test";
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            return o instanceof SimpleTestInfo;
+        }
+
+        @Override
+        public int hashCode() {
+            return getTechnicalName().hashCode();
+        }
+    }
+
+    @Test
+    public void testGetRareResponsesWithNoResponses() {
+        List<VectorResponse> responses = new ArrayList<>();
+        InformationLeakTest<SimpleTestInfo> test =
+                new InformationLeakTest<>(new SimpleTestInfo(), responses);
+
+        List<VectorResponse> rareResponses = test.getRareResponses(1);
+        assertTrue(rareResponses.isEmpty());
+    }
+
+    @Test
+    public void testGetRareResponsesWithUniqueResponse() {
+        List<VectorResponse> responses = new ArrayList<>();
+        TestVector vector1 = new TestVector("vector1");
+        TestVector vector2 = new TestVector("vector2");
+        TestVector vector3 = new TestVector("vector3");
+
+        ResponseFingerprint fingerprint1 =
+                new ResponseFingerprint(new ArrayList<>(), new ArrayList<>(), SocketState.CLOSED);
+        ResponseFingerprint fingerprint2 =
+                new ResponseFingerprint(new ArrayList<>(), new ArrayList<>(), SocketState.TIMEOUT);
+
+        // vector1 and vector2 have fingerprint1, vector3 has unique fingerprint2
+        responses.add(new VectorResponse(vector1, fingerprint1));
+        responses.add(new VectorResponse(vector2, fingerprint1));
+        responses.add(new VectorResponse(vector3, fingerprint2));
+
+        InformationLeakTest<SimpleTestInfo> test =
+                new InformationLeakTest<>(new SimpleTestInfo(), responses);
+
+        // Get responses that occurred at most once
+        List<VectorResponse> rareResponses = test.getRareResponses(1);
+        assertEquals(1, rareResponses.size());
+        assertEquals(vector3, rareResponses.get(0).getVector());
+        assertEquals(fingerprint2, rareResponses.get(0).getFingerprint());
+    }
+
+    @Test
+    public void testGetRareResponsesWithMultipleRareResponses() {
+        List<VectorResponse> responses = new ArrayList<>();
+        TestVector vector1 = new TestVector("vector1");
+        TestVector vector2 = new TestVector("vector2");
+        TestVector vector3 = new TestVector("vector3");
+        TestVector vector4 = new TestVector("vector4");
+
+        ResponseFingerprint fingerprint1 =
+                new ResponseFingerprint(new ArrayList<>(), new ArrayList<>(), SocketState.CLOSED);
+        ResponseFingerprint fingerprint2 =
+                new ResponseFingerprint(new ArrayList<>(), new ArrayList<>(), SocketState.TIMEOUT);
+        ResponseFingerprint fingerprint3 =
+                new ResponseFingerprint(
+                        new ArrayList<>(), new ArrayList<>(), SocketState.DATA_AVAILABLE);
+
+        // vector1 and vector2 have fingerprint1, vector3 has fingerprint2, vector4 has fingerprint3
+        responses.add(new VectorResponse(vector1, fingerprint1));
+        responses.add(new VectorResponse(vector2, fingerprint1));
+        responses.add(new VectorResponse(vector3, fingerprint2));
+        responses.add(new VectorResponse(vector4, fingerprint3));
+
+        InformationLeakTest<SimpleTestInfo> test =
+                new InformationLeakTest<>(new SimpleTestInfo(), responses);
+
+        // Get responses that occurred at most twice
+        List<VectorResponse> rareResponses = test.getRareResponses(2);
+        assertEquals(4, rareResponses.size()); // All responses occur at most twice
+
+        // Get responses that occurred at most once
+        rareResponses = test.getRareResponses(1);
+        assertEquals(2, rareResponses.size()); // vector3 and vector4
+
+        // Verify the rare responses
+        boolean foundVector3 = false;
+        boolean foundVector4 = false;
+        for (VectorResponse response : rareResponses) {
+            if (response.getVector().equals(vector3)) {
+                foundVector3 = true;
+                assertEquals(fingerprint2, response.getFingerprint());
+            } else if (response.getVector().equals(vector4)) {
+                foundVector4 = true;
+                assertEquals(fingerprint3, response.getFingerprint());
+            }
+        }
+        assertTrue(foundVector3);
+        assertTrue(foundVector4);
+    }
+
+    @Test
+    public void testGetRareResponsesWithNoRareResponses() {
+        List<VectorResponse> responses = new ArrayList<>();
+        TestVector vector1 = new TestVector("vector1");
+        TestVector vector2 = new TestVector("vector2");
+        TestVector vector3 = new TestVector("vector3");
+
+        ResponseFingerprint fingerprint1 =
+                new ResponseFingerprint(new ArrayList<>(), new ArrayList<>(), SocketState.CLOSED);
+
+        // All vectors have the same fingerprint
+        responses.add(new VectorResponse(vector1, fingerprint1));
+        responses.add(new VectorResponse(vector2, fingerprint1));
+        responses.add(new VectorResponse(vector3, fingerprint1));
+
+        InformationLeakTest<SimpleTestInfo> test =
+                new InformationLeakTest<>(new SimpleTestInfo(), responses);
+
+        // Get responses that occurred at most twice
+        List<VectorResponse> rareResponses = test.getRareResponses(2);
+        assertTrue(rareResponses.isEmpty()); // All responses occur 3 times
+
+        // Get responses that occurred at most 3 times
+        rareResponses = test.getRareResponses(3);
+        assertEquals(3, rareResponses.size()); // All responses occur exactly 3 times
+    }
+
+    @Test
+    public void testGetRareResponsesIntegrationWithExtendedTest() {
+        List<VectorResponse> initialResponses = new ArrayList<>();
+        TestVector vector1 = new TestVector("vector1");
+        TestVector vector2 = new TestVector("vector2");
+
+        ResponseFingerprint fingerprint1 =
+                new ResponseFingerprint(new ArrayList<>(), new ArrayList<>(), SocketState.CLOSED);
+        ResponseFingerprint fingerprint2 =
+                new ResponseFingerprint(new ArrayList<>(), new ArrayList<>(), SocketState.TIMEOUT);
+
+        initialResponses.add(new VectorResponse(vector1, fingerprint1));
+        initialResponses.add(new VectorResponse(vector2, fingerprint2));
+
+        InformationLeakTest<SimpleTestInfo> test =
+                new InformationLeakTest<>(new SimpleTestInfo(), initialResponses);
+
+        // Initially both responses are unique
+        List<VectorResponse> rareResponses = test.getRareResponses(1);
+        assertEquals(2, rareResponses.size());
+
+        // Extend the test with more responses
+        List<VectorResponse> additionalResponses = new ArrayList<>();
+        additionalResponses.add(new VectorResponse(vector1, fingerprint1));
+        additionalResponses.add(new VectorResponse(vector1, fingerprint1));
+
+        test.extendTestWithVectorResponses(additionalResponses);
+
+        // Now only vector2's response is rare (occurring once)
+        rareResponses = test.getRareResponses(1);
+        // Since vector1 now occurs 3 times (1 initial + 2 additional) with fingerprint1,
+        // but getRareResponses returns one VectorResponse per vector that had that fingerprint,
+        // we expect 1 response for vector2 (which still occurs once)
+        assertEquals(1, rareResponses.size());
+        assertEquals(vector2, rareResponses.get(0).getVector());
+        assertEquals(fingerprint2, rareResponses.get(0).getFingerprint());
+    }
+}

--- a/TLS-Server-Scanner/src/main/java/de/rub/nds/tlsscanner/serverscanner/probe/result/sessionticket/TicketPaddingOracleResult.java
+++ b/TLS-Server-Scanner/src/main/java/de/rub/nds/tlsscanner/serverscanner/probe/result/sessionticket/TicketPaddingOracleResult.java
@@ -14,7 +14,6 @@ import de.rub.nds.tlsscanner.core.vector.VectorResponse;
 import de.rub.nds.tlsscanner.core.vector.statistics.InformationLeakTest;
 import de.rub.nds.tlsscanner.core.vector.statistics.TestInfo;
 import de.rub.nds.tlsscanner.serverscanner.leak.TicketPaddingOracleSecondByteTestInfo;
-import de.rub.nds.tlsscanner.serverscanner.probe.SessionTicketPaddingOracleProbe;
 import de.rub.nds.tlsscanner.serverscanner.probe.sessionticket.vector.TicketPaddingOracleVectorLast;
 import de.rub.nds.tlsscanner.serverscanner.probe.sessionticket.vector.TicketPaddingOracleVectorSecond;
 import de.rub.nds.tlsscanner.serverscanner.probe.sessionticket.vector.TicketVector;
@@ -76,8 +75,7 @@ public class TicketPaddingOracleResult implements SummarizableTestResult {
     private <V extends TicketVector, T extends TestInfo> List<V> getVectorsWithRareResponses(
             InformationLeakTest<T> leakTest, Class<V> vectorClass, int maxOccurences) {
         List<V> ret = new ArrayList<>();
-        for (VectorResponse response :
-                SessionTicketPaddingOracleProbe.getRareResponses(leakTest, maxOccurences)) {
+        for (VectorResponse response : leakTest.getRareResponses(maxOccurences)) {
             ret.add(vectorClass.cast(response.getVector()));
         }
         return ret;


### PR DESCRIPTION
## Summary
- Moved `getRareResponses` method from `SessionTicketPaddingOracleProbe` to `InformationLeakTest` as a non-static method
- Updated all callers to use the new method location
- Added comprehensive unit tests for the method

## Details
This PR addresses issue #371 by refactoring the `getRareResponses` method to make it reusable across different probes. The method identifies response patterns that occur rarely (at most N times) across all test vectors, which is useful for various padding oracle and timing attack analyses.

### Changes made:
1. **Moved method to InformationLeakTest**: The method is now a proper instance method of `InformationLeakTest`, allowing it to access the test's vector containers directly
2. **Fixed implementation**: The method now correctly counts total occurrences across all vectors when determining rare responses
3. **Updated callers**: Both `SessionTicketPaddingOracleProbe` and `TicketPaddingOracleResult` now use the new method location
4. **Added tests**: Created comprehensive unit tests covering various scenarios including:
   - Empty response lists
   - Unique responses
   - Multiple rare responses
   - No rare responses
   - Integration with extended test data

## Test plan
- [x] Unit tests pass for the new `getRareResponses` method
- [x] Existing tests still pass after refactoring
- [x] Code compiles without warnings
- [x] Spotless formatting applied